### PR TITLE
Copy image data into CGDataProvider to avoid bad access

### DIFF
--- a/ios/PPSSignatureView_Metal.m
+++ b/ios/PPSSignatureView_Metal.m
@@ -480,22 +480,26 @@ static simd_float4x4 matrix_translation(float tx, float ty, float tz) {
                    mipmapLevel:0];
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGDataProviderRef dataProvider = CGDataProviderCreateWithData(NULL, imageBytes, totalBytes, NULL);
-    
+
+    // Create NSData to properly manage the buffer lifecycle
+    NSData *imageData = [NSData dataWithBytes:imageBytes length:totalBytes];
+    free(imageBytes); // Free the malloc'd buffer since NSData has copied it
+
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithCFData((__bridge CFDataRef)imageData);
+
     CGImageRef cgImage = CGImageCreate(imageSize.width, imageSize.height,
                                       8, 32, bytesPerRow,
                                       colorSpace,
                                       kCGImageAlphaFirst | kCGBitmapByteOrder32Little,
                                       dataProvider, NULL, false,
                                       kCGRenderingIntentDefault);
-    
+
     UIImage *image = [UIImage imageWithCGImage:cgImage];
-    
+
     // Cleanup
     CGImageRelease(cgImage);
     CGDataProviderRelease(dataProvider);
     CGColorSpaceRelease(colorSpace);
-    free(imageBytes);
     
     return image;
 }


### PR DESCRIPTION
Here's what claude had to say about root cause:
```
  Root Cause Analysis:

  The crash occurs when creating a CGDataProvider with a buffer that's not properly accessible for reading. In PPSSignatureView_Metal.m:483:

  CGDataProviderRef dataProvider = CGDataProviderCreateWithData(NULL, imageBytes, totalBytes, NULL);

  The Problem:
  The imageBytes buffer is allocated with malloc() on line 475, but there's a critical memory management issue. The buffer is being freed immediately after creating the UIImage on line 498:

  free(imageBytes);  // Line 498 - Buffer freed too early

  However, CGDataProviderCreateWithData with a NULL deallocator (4th parameter) doesn't take ownership of the buffer. This means:

  1. The buffer imageBytes is freed immediately after the UIImage is created
  2. CoreGraphics still holds a reference to the freed memory through the CGDataProvider
  3. When CoreGraphics later tries to access this buffer (e.g., during PNG encoding via UIImagePNGRepresentation in RSSignatureView.m:219), it reads from deallocated memory
  4. This triggers the ERROR_CGDataProviderCreateWithData_BufferIsNotReadable error

  The Fix:
  The library should either:

  1. Use a proper deallocator callback to free the buffer when CoreGraphics is done with it:
  CGDataProviderRef dataProvider = CGDataProviderCreateWithData(NULL, imageBytes, totalBytes, releaseDataCallback);

  2. Or copy the data into the CGDataProvider:
  CGDataProviderRef dataProvider = CGDataProviderCreateWithCopyOfData([NSData dataWithBytes:imageBytes length:totalBytes]);
```